### PR TITLE
When finished, call return

### DIFF
--- a/docs/source/solver.rst
+++ b/docs/source/solver.rst
@@ -1,2 +1,6 @@
 Using the Solver
 ================
+
+The Solver for Developers
+=========================
+

--- a/solver.py
+++ b/solver.py
@@ -166,12 +166,13 @@ class Process:
         # TODO
         while not Process.IS_FINISHED:
             if __debug__:
-                # time.sleep(.05)
+                time.sleep(.05)
                 self._log_work(self.work)
             if self.rank == Process.ROOT and Process.INITIAL_POS.pos in self.resolved:
                 logging.info('Finished')
                 print (self.resolved[Process.INITIAL_POS.pos])
-                MPI.Finalize()
+                return
+                # MPI.Finalize()
             if self.work.empty():
                 self.add_job(Job(Job.CHECK_FOR_UPDATES))
             job = self.work.get()

--- a/solver.py
+++ b/solver.py
@@ -166,12 +166,12 @@ class Process:
         # TODO
         while not Process.IS_FINISHED:
             if __debug__:
-                time.sleep(.05)
+                # time.sleep(.05)
                 self._log_work(self.work)
             if self.rank == Process.ROOT and Process.INITIAL_POS.pos in self.resolved:
                 logging.info('Finished')
-                print (self.resolved[Process.INITIAL_POS])
-                comm.finalize(1)
+                print (self.resolved[Process.INITIAL_POS.pos])
+                MPI.Finalize()
             if self.work.empty():
                 self.add_job(Job(Job.CHECK_FOR_UPDATES))
             job = self.work.get()


### PR DESCRIPTION
So when MPI.Finalize() is called in process.run(), I get the following error:

**\* The MPI_Finalize() function was called after MPI_FINALIZE was invoked.
**\* This is disallowed by the MPI standard.
**\* Your MPI job will now abort.

As of now, I'm calling return in run(). I left MPI.Finalize() as a comment.

Per the open mpi4py docs: 

Note MPI_Finalize() is registered (by using Python C/API function Py_AtExit()) for being automatically called when Python processes exit, but only if mpi4py actually initialized Therefore, there is no need to call Finalize() from Python to ensure MPI finalization.

So maybe we just need to call return?
