### PR TITLE
Removed Process.finished

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -96,9 +96,6 @@ class Process:
                                   # remaining.
         self._pending = {}        # job_id -> [ Job, GameStates, ... ]
                                   # Resolved.
-        # Main process will terminate everyone by bcasting the value of
-        # finished to True.
-        self.finished = False
 
     def add_job(self, job):
         """


### PR DESCRIPTION
This variable is unused, and thus unnecessary. Also, it has the same name as our Process.finished() method, which means that our code sometimes tries to call it a function in dispatch().
